### PR TITLE
Handle alternative Pelican style links too

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,8 +32,9 @@ It can handle:
     This way fixed name references can be defined to prevent links from going
     stale after headings have been changed.
 - **local link format of pelican**:
-    mdnav handles `|filename| ...` links as expected, for example
-    `[link](|filename|./second.md)`.
+    mdnav handles `|filename| ...` and `{filename} ...` links as expected, for
+    example `[link](|filename|./second.md)` and
+    `[link]({filename}../posts/second.md)`.
 
 Note, all links above are functional with vim and mdnav installed.
 While mdnav is inspired by [follow-markdown-links][fml], mdnav can handle many

--- a/ftplugin/markdown/mdnav.py
+++ b/ftplugin/markdown/mdnav.py
@@ -80,6 +80,9 @@ def open_link(target, current_file, open_in_vim_extensions=set()):
     if target.startswith('|filename|'):
         target = target[len('|filename|'):]
 
+    if target.startswith('{filename}'):
+        target = target[len('{filename}'):]
+
     return VimOpen(anchor_path(target, current_file))
 
 
@@ -284,12 +287,12 @@ def parse_link(cursor, lines):
     if not indirect_ref:
         indirect_ref = m.group('text')
 
-    indrect_link_pattern = re.compile(
+    indirect_link_pattern = re.compile(
         r'^\[' + re.escape(indirect_ref) + r'\]:(.*)$'
     )
 
     for line in lines:
-        m = indrect_link_pattern.match(line)
+        m = indirect_link_pattern.match(line)
 
         if m:
             return m.group(1).strip()


### PR DESCRIPTION
Pelican has another style of internal linking, through { }

Also fixed a small typo in a variable name.