### PR TITLE
Support (simple) wiki style links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,8 +36,10 @@ It can handle:
     example `[link](|filename|./second.md)` and
     `[link]({filename}../posts/second.md)`.
 - **wiki style links**:
-    for links of the form `[[foo]]` will use `foo` as the base, append `.md` and
-    then `foo.md` will be opened.
+    for links of the form `[[foo]]` will use `foo` as the base, append `.md`
+    and then `foo.md` will be opened. Line numbers and anchors are also
+    supported, in which case a missing `.md` will be inserted at the correct
+    place.
 
 Note, all links above are functional with vim and mdnav installed.
 While mdnav is inspired by [follow-markdown-links][fml], mdnav can handle many

--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,9 @@ It can handle:
     mdnav handles `|filename| ...` and `{filename} ...` links as expected, for
     example `[link](|filename|./second.md)` and
     `[link]({filename}../posts/second.md)`.
+- **wiki style links**:
+    for links of the form `[[foo]]` will use `foo` as the base, append `.md` and
+    then `foo.md` will be opened.
 
 Note, all links above are functional with vim and mdnav installed.
 While mdnav is inspired by [follow-markdown-links][fml], mdnav can handle many

--- a/ftplugin/markdown/mdnav.py
+++ b/ftplugin/markdown/mdnav.py
@@ -265,6 +265,10 @@ def parse_link(cursor, lines):
         _logger.info('could not find link text')
         return None
 
+    m = wikilink_pattern.match(link_text)
+    if m is not None:
+        return '{}.md'.format(m.group('text').strip())
+
     m = link_pattern.match(link_text)
 
     if not m:
@@ -327,6 +331,17 @@ link_pattern = re.compile(r'''
                 )
             \]
         )
+    )
+    .*                  # any non matching characters
+    $
+''', re.VERBOSE)
+
+wikilink_pattern = re.compile(r'''
+    ^
+    (?P<link>
+        \[                      # start of link text
+            (?P<text>[^\]]*)    # link text
+        \]\]                    # end of link text
     )
     .*                  # any non matching characters
     $

--- a/ftplugin/markdown/mdnav.py
+++ b/ftplugin/markdown/mdnav.py
@@ -267,12 +267,12 @@ def parse_link(cursor, lines):
 
     m = wikilink_pattern.match(link_text)
     if m is not None:
-        target = m.group('text').strip
+        target = m.group('text').strip()
         if '.md' not in target:
-            if '#' in target
+            if '#' in target:
                 # There's an anchor, put the extension before it
                 return target.replace('#', '.md#', 1)
-            if ':' in target
+            if ':' in target:
                 # There's a line number, likewise put the extension before it
                 return target.replace(':', '.md:', 1)
             return '{}.md'.format(target)

--- a/ftplugin/markdown/mdnav.py
+++ b/ftplugin/markdown/mdnav.py
@@ -267,7 +267,16 @@ def parse_link(cursor, lines):
 
     m = wikilink_pattern.match(link_text)
     if m is not None:
-        return '{}.md'.format(m.group('text').strip())
+        target = m.group('text').strip
+        if '.md' not in target:
+            if '#' in target
+                # There's an anchor, put the extension before it
+                return target.replace('#', '.md#', 1)
+            if ':' in target
+                # There's a line number, likewise put the extension before it
+                return target.replace(':', '.md:', 1)
+            return '{}.md'.format(target)
+        return target
 
     m = link_pattern.match(link_text)
 

--- a/tests/test_mdnav.py
+++ b/tests/test_mdnav.py
@@ -12,6 +12,8 @@ parse_link_cases = [
     (['foo [b^ar][bar]', '[bar]: |filename|./baz.md'], '|filename|./baz.md'),
     (['foo [b^ar][bar] [bar][baz]', '[bar]: |filename|./baz.md'], '|filename|./baz.md'),
     (['foo [b^ar][bar] [bar][baz]', '[bar]: {filename}./baz.md'], '{filename}./baz.md'),
+    (['foo [[baz]]'], 'baz.md'),
+    (['foo [[baz.md]]'], 'baz.md'),
 
     # empty link target
     (['foo [b^ar][]', '[bar]: baz.md'], 'baz.md'),


### PR DESCRIPTION
Support [[wikilink]] links, which will expand to in this case `wikilink.md`.