### PR TITLE
convert %20 into spaces

### DIFF
--- a/ftplugin/markdown/mdnav.py
+++ b/ftplugin/markdown/mdnav.py
@@ -148,7 +148,9 @@ class VimOpen(Action):
         path = parse_path(self.target)
 
         # TODO: make space handling more robust?
-        vim.command('e {}'.format(path.path.replace(' ', '\\ ')))
+        escapedTargetPath = re.sub(r'%20| ', '\\ ', path.path);
+
+        vim.command('e {}'.format(escapedTargetPath))
         if path.line is not None:
             try:
                 line = int(path.line)


### PR DESCRIPTION
I've been using this to navigate to relative paths that use `%20` to escape spaces, and thought it might be beneficial to make available to others.
This basically does `s/%20| /\\ /g` on the target path before calling `:edit`. I've done a bit of hand testing with `%20`, ` `, and mixed paths and they seem to work.